### PR TITLE
Integrationtest instrumentation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,13 @@
 ###nm20151113 DIRS          = main neutral eldyn flip plasma dummygptl driver
 ###nm20151110 DIRS          = main neutral flip eldyn plasma dummygptl driver
 SHELL=/bin/csh
-DIRS          = dummygptl main neutral eldyn flip plasma driver
+
+ifeq ($(TESTING),yes)
+  DIRS          = integration_testing dummygptl main neutral eldyn flip plasma driver
+else
+  DIRS          = dummygptl main neutral eldyn flip plasma driver
+endif
+
 GPTL_INCFLAGS = -I../dummygptl/
 GPTL_LDFLAGS  = -L../dummygptl -lgptl
 PPP_FLAGS     = --Fmodule=module_decomp --Free --comment --HaloSize=10

--- a/src/integration_testing/Makefile
+++ b/src/integration_testing/Makefile
@@ -1,0 +1,7 @@
+# plasma Makefile
+
+TOP = ..
+
+PSRCS = ModelDataInstances_Class.f90 
+
+include $(TOP)/Makefile.common

--- a/src/integration_testing/ModelDataInstances_Class.f90
+++ b/src/integration_testing/ModelDataInstances_Class.f90
@@ -1,0 +1,427 @@
+! ModelDataInstances_Class.f90
+! 
+!  Copyright (2017), Joseph Schoonover, Cooperative Institute for Research in
+!  Environmental Sciences, NOAA, (joseph.schoonover@noaa.gov)
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////// !
+
+MODULE ModelDataInstances_Class
+
+!src/common/
+USE Module_Precision
+
+IMPLICIT NONE
+
+   INTEGER, PARAMETER      :: strLen = 30
+   CHARACTER(6), PARAMETER :: strFMT = "(A30)"
+
+   TYPE ModelDataInstance
+      CHARACTER(strLen)               :: moduleName
+      CHARACTER(strLen)               :: subroutineName
+      CHARACTER(strLen)               :: statusCheckName
+      INTEGER                         :: lineNumber
+      INTEGER                         :: instanceID
+      INTEGER                         :: nObs
+      INTEGER                         :: arraySize
+      REAL(real_prec), ALLOCATABLE    :: array(:) 
+      TYPE(ModelDataInstance),POINTER :: next
+
+   END TYPE ModelDataInstance
+
+   TYPE ModelDataInstances
+      TYPE(ModelDataInstance), POINTER :: head, current, tail
+
+      CONTAINS
+
+      PROCEDURE :: Build       => Build_ModelDataInstances
+      PROCEDURE :: Trash       => Trash_ModelDataInstances 
+      PROCEDURE :: AddInstance => AddInstance_ModelDataInstances 
+
+      PROCEDURE :: SetNames            => SetNames_ModelDataInstances
+      PROCEDURE :: GetNames            => GetNames_ModelDataInstances
+      PROCEDURE :: PointToInstance     => PointToInstance_ModelDataInstances
+      PROCEDURE :: ThereAreNoInstances
+        
+      PROCEDURE :: Write_ModelDataInstances
+      PROCEDURE :: Read_ModelDataInstances
+
+    END TYPE ModelDataInstances
+
+ INTEGER, PRIVATE, PARAMETER :: defaultNameLength = 40
+ CONTAINS
+!
+!
+!==================================================================================================!
+!---------------------------- CONSTRUCTOR/DESTRUCTOR ROUTINES -------------------------------------!
+!==================================================================================================!
+!
+ SUBROUTINE Build_ModelDataInstances( theInstances  )
+
+   IMPLICIT NONE
+   CLASS( ModelDataInstances ) :: theInstances
+   
+     theInstances % head => NULL( )
+     ! Point the tail to null
+     theInstances % tail => NULL()
+     ! Set the current position to Null
+     theInstances % current => NULL( )
+
+
+ END SUBROUTINE Build_ModelDataInstances
+!
+ SUBROUTINE Trash_ModelDataInstances( theInstances )
+
+   IMPLICIT NONE
+   CLASS( ModelDataInstances ) :: theInstances
+   ! LOCAL 
+   TYPE( ModelDataInstance ), POINTER :: pNext
+   
+     ! Set the current position of the list to the head
+     theInstances % current => theInstances % head
+     
+     ! Scroll through the list until the current position is nullified
+     DO WHILE ( ASSOCIATED( theInstances % current ) )
+
+        ! temporarily point to the next in the list
+        pNext => theInstances % current % next 
+
+        ! Deallocate memory pointed to by current position
+        DEALLOCATE( theInstances % current % array )
+        DEALLOCATE( theInstances % current ) 
+
+        ! Update current position
+        theInstances % current => pNext 
+
+     ENDDO
+      
+
+ END SUBROUTINE Trash_ModelDataInstances
+!
+!
+!==================================================================================================!
+!---------------------------------- ACCESSOR ROUTINES ---------------------------------------------!
+!==================================================================================================!
+!
+! 
+ SUBROUTINE SetNames_ModelDataInstances( theInstances, moduleName, subroutineName, statusCheckName, instanceID )
+
+   IMPLICIT NONE
+   CLASS( ModelDataInstances ), INTENT(inout) :: theInstances
+   CHARACTER(*), INTENT(IN)                   :: moduleName, subroutineName, statusCheckName
+   INTEGER, OPTIONAL, INTENT(IN)              :: instanceID
+      
+      IF( PRESENT( instanceID ) )THEN
+         CALL theInstances % PointToInstance( instanceID )  
+      ENDIF
+      
+      theInstances % current % moduleName      = TRIM(moduleName)
+      theInstances % current % subroutineName  = TRIM(subroutineName)
+      theInstances % current % statusCheckName = TRIM(statusCheckName)
+
+ END SUBROUTINE SetNames_ModelDataInstances
+!
+ SUBROUTINE GetNames_ModelDataInstances( theInstances, moduleName, subroutineName, statusCheckName, instanceID )
+
+   IMPLICIT NONE
+   CLASS( ModelDataInstances ), INTENT(in) :: theInstances
+   CHARACTER(*), INTENT(out)               :: moduleName, subroutineName, statusCheckName
+   INTEGER, OPTIONAL, INTENT(IN)           :: instanceID
+      
+      IF( PRESENT( instanceID ) )THEN
+         CALL theInstances % PointToInstance( instanceID )
+      ENDIF
+      
+      moduleName      = theInstances % current % moduleName
+      subroutineName  = theInstances % current % subroutineName
+      statusCheckName = theInstances % current % statusCheckName
+
+ END SUBROUTINE GetNames_ModelDataInstances
+!
+!
+!==================================================================================================!
+!-------------------------------- Linked-List Type Operations -------------------------------------!
+!==================================================================================================!
+!
+! 
+ FUNCTION ThereAreNoInstances( theInstances ) RESULT( TorF )
+  IMPLICIT NONE
+  CLASS( ModelDataInstances ) :: theInstances
+  LOGICAL              :: TorF
+
+     TorF = .NOT.( ASSOCIATED( theInstances % head  ) )
+     
+ END FUNCTION ThereAreNoInstances
+!
+ SUBROUTINE AddInstance_ModelDataInstances( theInstances, &
+                                            moduleName, &
+                                            subroutineName, &
+                                            statusCheckName, &
+                                            lineNumber,& 
+                                            arraySize )
+ 
+   IMPLICIT NONE
+   CLASS( ModelDataInstances ), INTENT(inout) :: theInstances
+   CHARACTER(*)                               :: moduleName
+   CHARACTER(*)                               :: subroutineName
+   CHARACTER(*)                               :: statusCheckName
+   INTEGER                                    :: lineNumber, arraySize
+   ! LOCAL
+   INTEGER :: allocationStatus
+
+     ! Check to see if this list is empty
+     IF( theInstances % ThereAreNoInstances() )THEN
+     
+        ALLOCATE( theInstances % head, STAT = allocationStatus )
+        IF( allocationStatus /=0 )THEN
+           PRINT*, 'MODULE ModelDataInstances_Class.f90 : S/R AddInstance : Memory not allocated for next entry in list.'
+        ENDIF      
+      
+        ! Point the current position to the head
+        theInstances % current => theInstances % head
+        ! Set the data
+        CALL theInstances % SetNames( moduleName, subroutineName, statusCheckName  )
+        
+        theInstances % current % instanceID = CharToIntHashFunction( theInstances % current % statusCheckName )
+        theInstances % current % nObs       = 0
+        theInstances % current % arraySize   = arraySize
+        ALLOCATE( theInstances % current % array(1:arraySize) )
+        theInstances % current % array = 0.0_real_prec
+        
+        ! Point the next to null and the tail to current
+        theInstances % current % next => NULL( )
+        theInstances % tail => theInstances % current
+        
+     ELSE ! the list is not empty
+    
+        ! Then we allocate space for the next item in the list    
+        ALLOCATE( theInstances % tail % next, STAT = allocationStatus )
+        IF( allocationStatus /=0 )THEN
+           PRINT*, 'MODULE ModelDataInstances_Class.f90 : S/R AddInstance : Memory not allocated for next entry in list.'
+        ENDIF      
+        
+        ! Reassign the tail
+        theInstances % tail => theInstances % tail % next
+        
+        ! Set the current to the tail
+        theInstances % current => theInstances % tail
+  
+        ! Fill in the data
+        CALL theInstances % SetNames( moduleName, subroutineName, statusCheckName  )
+        
+        ! Fill in the key information
+        theInstances % current % instanceID = CharToIntHashFunction( theInstances % current % statusCheckName )
+        theInstances % current % nObs       = 0
+        theInstances % current % arraySize   = arraySize
+        ALLOCATE( theInstances % current % array(1:arraySize) )
+        theInstances % current % array = 0.0_real_prec
+        
+        ! Point the next to null and the tail to current
+        theInstances % current % next => NULL( )
+        
+     ENDIF
+
+ END SUBROUTINE AddInstance_ModelDataInstances
+!
+ SUBROUTINE PointToInstance_ModelDataInstances( theInstances, instanceID, instanceFound )
+ 
+   IMPLICIT NONE
+   CLASS( ModelDataInstances )    :: theInstances
+   INTEGER, INTENT(IN)            :: instanceID
+   LOGICAL, OPTIONAL, INTENT(OUT) :: instanceFound
+   
+   
+      theInstances % current => theInstances % head ! Point to the head of the list
+      IF( PRESENT( instanceFound ) )THEN
+        instanceFound = .FALSE.
+      ENDIF
+      
+      DO WHILE(ASSOCIATED(theInstances % current))
+      
+         IF( theInstances % current % instanceID == instanceID )THEN
+            IF( PRESENT( instanceFound ) )THEN
+              instanceFound = .TRUE.
+            ENDIF
+            EXIT
+         ENDIF
+         theInstances % current => theInstances % current % next
+       
+      ENDDO
+      
+      
+ END SUBROUTINE PointToInstance_ModelDataInstances
+!
+ SUBROUTINE Write_ModelDataInstances( theInstances, baseFileName )
+
+   IMPLICIT NONE
+   CLASS( ModelDataInstances ), INTENT(INOUT) :: theInstances 
+   CHARACTER(200), INTENT(IN)                 :: baseFileName
+   ! LOCAL
+   INTEGER :: k, fUnit, fUnit2, recID, i
+   CHARACTER(3) :: countChar 
+
+      theInstances % current => theInstances % head
+      WRITE( countChar, '(I3.3)' ) theInstances % current % nObs
+      OPEN( UNIT = NewUnit(fUnit), &
+            FILE = TRIM(baseFileName)//'.instance.header', &
+            FORM = 'FORMATTED', &
+            ACCESS = 'SEQUENTIAL', &
+            ACTION = 'WRITE' )
+            
+      OPEN( UNIT = NewUnit(fUnit2), &
+            FILE = TRIM(baseFileName)//'.'//countChar//'.instance', &
+            FORM = 'UNFORMATTED', &
+            ACCESS = 'DIRECT', &
+            ACTION = 'WRITE', &
+            RECL   = real_prec ) 
+
+      k     = 0
+      recID = 0
+      DO WHILE( ASSOCIATED(theInstances % current) )
+         k = k+1
+
+
+         WRITE(fUnit,*) TRIM( theInstances % current % moduleName )
+         WRITE(fUnit,*) TRIM( theInstances % current % subroutineName )
+         WRITE(fUnit,*) TRIM( theInstances % current % statusCheckName )
+         WRITE(fUnit,*) theInstances % current % lineNumber
+         WRITE(fUnit,*) theInstances % current % arraySize
+         WRITE(fUnit,*) theInstances % current % instanceID
+         WRITE(fUnit,*) '------------------------------------------------------------'
+
+         theInstances % current => theInstances % current % next
+
+       
+         DO i = 1, theInstances % current % arraySize
+            recID = recID + 1
+            WRITE( fUnit2, REC=recID ) theInstances % current  % array(i)
+         ENDDO
+
+      ENDDO
+      CLOSE(fUnit)
+      CLOSE(fUnit2)
+
+
+ END SUBROUTINE Write_ModelDataInstances
+!
+ SUBROUTINE Read_ModelDataInstances( theInstances, baseFileName )
+
+   IMPLICIT NONE
+   CLASS( ModelDataInstances ), INTENT(INOUT) :: theInstances 
+   CHARACTER(200), INTENT(IN)                 :: baseFileName
+   ! LOCAL
+   INTEGER        :: k, fUnit, fUnit2, recID, i
+   CHARACTER(3)   :: countChar 
+   CHARACTER(strLen) :: moduleName, subroutineName, statusCheckName, dummyChar
+   INTEGER        :: lineNumber, arraySize, instanceID
+
+      WRITE( countChar, '(I3.3)' ) theInstances % current % nObs
+      OPEN( UNIT = NewUnit(fUnit), &
+            FILE = TRIM(baseFileName)//'.instance.header', &
+            FORM = 'FORMATTED', &
+            ACCESS = 'SEQUENTIAL', &
+            ACTION = 'READ' )
+            
+      OPEN( UNIT = NewUnit(fUnit2), &
+            FILE = TRIM(baseFileName)//'.'//countChar//'.instance', &
+            FORM = 'UNFORMATTED', &
+            ACCESS = 'DIRECT', &
+            ACTION = 'READ', &
+            RECL   = real_prec ) 
+
+      k     = 0
+      recID = 0
+      DO WHILE( ASSOCIATED(theInstances % current) )
+         k = k+1
+
+
+         READ(fUnit,strFMT) moduleName 
+         READ(fUnit,strFMT) subroutineName
+         READ(fUnit,strFMT) statusCheckName
+         READ(fUnit,*) lineNumber
+         READ(fUnit,*) arraySize
+         READ(fUnit,*) instanceID
+         READ(fUnit,strFMT) dummyChar
+
+         CALL theInstances % AddInstance( moduleName, &
+                                          subroutineName, &
+                                          statusCheckName, &
+                                          lineNumber, &
+                                          arraySize )
+                                          
+
+       
+         DO i = 1, theInstances % current % arraySize
+            recID = recID + 1
+            READ( fUnit2, REC=recID ) theInstances % current  % array(i)
+         ENDDO
+
+      ENDDO
+      CLOSE(fUnit)
+      CLOSE(fUnit2)
+
+
+ END SUBROUTINE Read_ModelDataInstances
+!
+ FUNCTION CharToIntHashFunction( inputChar ) RESULT( hash )
+    IMPLICIT NONE
+    CHARACTER(strLen) :: inputChar
+    INTEGER           :: hash
+    ! Local
+    CHARACTER(strLen) :: localChar
+    INTEGER           :: i
+
+       localChar = UpperCase( inputChar )
+      
+       hash = 5381
+       DO i = 1, LEN_TRIM(localChar)
+          hash = ( ISHFT(hash,5)+hash ) + ICHAR( localChar(i:i) )
+       ENDDO
+
+ END FUNCTION CharToIntHashFunction
+!
+ FUNCTION UpperCase( str ) RESULT( upper )
+
+    IMPLICIT NONE
+    CHARACTER(strLen), INTENT(IN) :: str
+    CHARACTER(strLen)           :: Upper
+
+    INTEGER :: ic, i
+
+    CHARACTER(27), PARAMETER :: cap = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ '
+    CHARACTER(27), PARAMETER :: low = 'abcdefghijklmnopqrstuvwxyz '
+
+    DO i = 1, LEN_TRIM(str)
+        ic = INDEX(low, str(i:i))
+        IF (ic > 0)THEN
+         Upper(i:i) = cap(ic:ic)
+        ELSE
+         Upper(i:i) = str(i:i)
+        ENDIF
+    ENDDO
+
+ END FUNCTION UpperCase
+!
+ INTEGER FUNCTION NewUnit(thisunit)
+ 
+   IMPLICIT NONE
+   INTEGER, INTENT(out), OPTIONAL :: thisunit
+   ! Local
+   INTEGER, PARAMETER :: unitMin=100, unitMax=1000
+   LOGICAL :: isopened
+   INTEGER :: iUnit
+
+     newunit=-1
+
+     DO iUnit=unitMin, unitMax
+        ! Check to see IF this UNIT is opened
+        INQUIRE(UNIT=iUnit,opened=isopened)
+        IF( .not. isopened )THEN
+           newunit=iUnit
+           EXIT
+        ENDIF
+     ENDDO
+
+     IF (PRESENT(thisunit)) thisunit = newunit
+ 
+END FUNCTION NewUnit
+END MODULE ModelDataInstances_Class

--- a/src/integration_testing/example/CompareModelDataInstances.f90
+++ b/src/integration_testing/example/CompareModelDataInstances.f90
@@ -65,7 +65,7 @@ PROGRAM CompareModelDataInstances
         CALL mdi2 % Read_ModelDataInstances( TRIM(dir2)//'/'//TRIM(baseName), &
                                              i, fileExists ) 
 
-       ! CALL mdi1 % CompareWith( mdi2 )
+        CALL mdi1 % CompareWith( mdi2 )
 
      ENDDO
 

--- a/src/integration_testing/example/CompareModelDataInstances.f90
+++ b/src/integration_testing/example/CompareModelDataInstances.f90
@@ -1,0 +1,177 @@
+! CompareModelDataInstances_Driver.f90
+! 
+!  Copyright (2017), Joseph Schoonover, Cooperative Institute for Research in
+!  Environmental Sciences, NOAA, (joseph.schoonover@noaa.gov)
+!
+!  Author : Joseph Schoonover
+!  Creation Date : July 25, 2017
+!
+! ------------------------------------------------------------------------------------------------ !
+!
+! This program reads in model data instances from 
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////// !
+
+PROGRAM CompareModelDataInstances
+
+ USE Module_Precision
+ USE ModelDataInstances_Class
+
+ IMPLICIT NONE
+
+   TYPE(ModelDataInstances) :: mdi1, mdi2
+   INTEGER                  :: nTotalObs, i
+   CHARACTER(50)            :: dir1, dir2, baseName
+   CHARACTER(8)             :: date
+   CHARACTER(10)            :: time
+   CHARACTER(5)             :: zone
+   LOGICAL                  :: setupFail, fileExists
+   
+
+
+     ! Default settings
+     dir1      = './'
+     dir2      = './'
+     baseName  = 'foo'
+     nTotalObs = 0
+     setupFail = .FALSE.
+
+     ! Set up program from command line arguments
+     CALL InitializeFromCommandLine( )
+
+     CALL DATE_AND_TIME( DATE=date, TIME=time, ZONE=zone )
+     PRINT '(3x,A,2x,A,2x,A)' , date, time, zone
+
+     PRINT*, 'dir1 = '//TRIM(dir1)
+     PRINT*, 'dir2 = '//TRIM(dir1)
+     PRINT '(A,1x,I5)', 'nTotalObs = ', nTotalObs
+
+     IF( setupFail )THEN
+        PRINT*, '  cmdi setup failed!'
+        STOP
+     ENDIF
+
+     
+
+     ! Initialize the ModelDataInstances linked list, by pointing all of the
+     ! pointers to Null
+     CALL mdi1 % Build( ) ! mdi1 should refer to "new" version of data
+     CALL mdi2 % Build( ) ! mdi2 should refer to "old" version of data
+
+     DO i = 1, nTotalObs
+
+        CALL mdi1 % Read_ModelDataInstances( TRIM(dir1)//'/'//TRIM(baseName), &
+                                             i, fileExists ) 
+        CALL mdi2 % Read_ModelDataInstances( TRIM(dir2)//'/'//TRIM(baseName), &
+                                             i, fileExists ) 
+
+       ! CALL mdi1 % CompareWith( mdi2 )
+
+     ENDDO
+
+     CALL mdi1 % Trash( )
+     CALL mdi2 % Trash( )
+
+CONTAINS
+
+ SUBROUTINE InitializeFromCommandLine( )
+   IMPLICIT NONE
+
+   INTEGER       :: nArg, argID
+   CHARACTER(50) :: argname
+   LOGICAL       :: dir1Given, dir2Given, baseNameGiven, nGiven
+
+
+     dir1Given     = .FALSE.
+     dir2Given     = .FALSE.
+     baseNameGiven = .FALSE.
+     nGiven        = .FALSE.
+
+     nArg = command_argument_count( )
+
+     IF( nArg > 0 )THEN
+ 
+        DO argID = 1, nArg
+  
+          CALL get_command_argument( argID, argName )
+
+          SELECT CASE( TRIM(argName) )
+
+             CASE("--dir1")
+                dir1Given = .TRUE.
+             CASE("--dir2")
+                dir2Given = .TRUE.
+             CASE("--basename")
+                baseNameGiven = .TRUE.
+             CASE("--n")
+                nGiven = .TRUE.
+
+             CASE DEFAULT
+
+               IF( dir1Given )THEN
+
+                  dir1      = TRIM(argName) ! Capture the directory name
+                  dir1Given = .FALSE.
+
+               ELSEIF( dir2Given )THEN
+
+                  dir2      = TRIM(argName)
+                  dir2Given = .FALSE.
+
+               ELSEIF( baseNameGiven )THEN
+
+                  baseName      = TRIM(argName)
+                  baseNameGiven = .FALSE.
+
+               ELSEIF( nGiven )THEN
+               
+                  READ( argName, '(I50)') nTotalObs
+                  nGiven = .FALSE.
+ 
+               ENDIF
+
+          END SELECT 
+        ENDDO
+
+        
+        INQUIRE( FILE = TRIM(dir1)//'/'//TRIM(baseName)//'.mdi.hdr', &
+                 EXIST = fileExists )
+        IF( .NOT.(fileExists) )THEN
+          PRINT*, ' MDI Header file not found :'//TRIM(dir1)//TRIM(baseName)//'.mdi.hdr'
+          setupFail = .TRUE.
+        ENDIF
+
+        INQUIRE( FILE = TRIM(dir2)//'/'//TRIM(baseName)//'.mdi.hdr', &
+                 EXIST = fileExists )
+        IF( .NOT.(fileExists) )THEN
+          PRINT*, ' MDI Header file not found :'//TRIM(dir2)//TRIM(baseName)//'.mdi.hdr'
+          setupFail = .TRUE.
+        ENDIF
+
+        IF( nTotalObs == 0 )THEN
+          PRINT*, ' Number of observations need to be specified.'
+          setupFail = .TRUE.
+        ENDIF
+        
+     ELSE
+
+        ! List possible options
+        PRINT*, '  cmdi : Compare Model Data Instances'
+        PRINT*, '    A tool for aiding in integration testing.'
+        PRINT*, '--------------------------------------------------------------'
+        PRINT*, '  Usage : cmdi --dir1 /path/to/mdifiles '
+        PRINT*, '               --dir2 /path/to/other/mdifiles'
+        PRINT*, '               --basename < .mdi and .mdi.hdr prefix >'
+        PRINT*, '               --n < number of *.mdi files >'
+        PRINT*, '--------------------------------------------------------------'
+        PRINT*, ' This executable compares two sets of mdi header and binary '
+        PRINT*, ' files and reports the differences of recorded model instances.'
+        PRINT*, '--------------------------------------------------------------'
+        STOP
+        
+     ENDIF   
+
+
+ END SUBROUTINE InitializeFromCommandLine
+
+END PROGRAM CompareModelDataInstances

--- a/src/integration_testing/example/Makefile
+++ b/src/integration_testing/example/Makefile
@@ -1,10 +1,14 @@
 
 
 FC  = ifort
-OPT = -O0 -g -traceback -check all -check bounds -debug all 
+#OPT = -O0 -g -traceback -check all -check bounds -debug all 
+OPT = -O0 -g
 
 mdi_test : module_precision.o ModelDataInstances_Class.o ModelDataInstances_Driver.o	
 	${FC} ${OPT} module_precision.o ModelDataInstances_Class.o ModelDataInstances_Driver.o -o $@
+     
+cmdi : module_precision.o ModelDataInstances_Class.o CompareModelDataInstances.o	
+	${FC} ${OPT} module_precision.o ModelDataInstances_Class.o CompareModelDataInstances.o -o $@
      
 
 module_precision.o : ../../main/module_precision.f90
@@ -15,3 +19,6 @@ ModelDataInstances_Class.o : ../ModelDataInstances_Class.f90 module_precision.o
 
 ModelDataInstances_Driver.o : ModelDataInstances_Driver.f90 ModelDataInstances_Class.o module_precision.o
 	${FC} ${OPT} -c ModelDataInstances_Driver.f90 -o $@
+
+CompareModelDataInstances.o : CompareModelDataInstances.f90 ModelDataInstances_Class.o module_precision.o
+	${FC} ${OPT} -c CompareModelDataInstances.f90 -o $@

--- a/src/integration_testing/example/Makefile
+++ b/src/integration_testing/example/Makefile
@@ -1,0 +1,17 @@
+
+
+FC  = ifort
+OPT = -O0 -g -traceback -check all -check bounds -debug all 
+
+mdi_test : module_precision.o ModelDataInstances_Class.o ModelDataInstances_Driver.o	
+	${FC} ${OPT} module_precision.o ModelDataInstances_Class.o ModelDataInstances_Driver.o -o $@
+     
+
+module_precision.o : ../../main/module_precision.f90
+	${FC} ${OPT} -c ../../main/module_precision.f90 -o $@
+
+ModelDataInstances_Class.o : ../ModelDataInstances_Class.f90 module_precision.o
+	${FC} ${OPT} -c ../ModelDataInstances_Class.f90 -o $@
+
+ModelDataInstances_Driver.o : ModelDataInstances_Driver.f90 ModelDataInstances_Class.o module_precision.o
+	${FC} ${OPT} -c ModelDataInstances_Driver.f90 -o $@

--- a/src/integration_testing/example/ModelDataInstances_Driver.f90
+++ b/src/integration_testing/example/ModelDataInstances_Driver.f90
@@ -1,0 +1,118 @@
+! ModelDataInstances_Driver.f90
+! 
+!  Copyright (2017), Joseph Schoonover, Cooperative Institute for Research in
+!  Environmental Sciences, NOAA, (joseph.schoonover@noaa.gov)
+!
+!  Author : Joseph Schoonover
+!  Creation Date : July 25, 2017
+!
+! ------------------------------------------------------------------------------------------------ !
+!
+!  This example driver tests the functionality of the
+!  ModelDataInstances_Class.f90 module and provides examples the shows how to
+!  make use of the ModelDataInstances data structure and type-bound procedures
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////// !
+
+PROGRAM ModelDataInstances_Driver
+
+ USE Module_Precision
+ USE ModelDataInstances_Class
+
+
+   TYPE(ModelDataInstances) :: mdi
+   REAL(real_prec)          :: sampleArray1(1:100)       
+   REAL(real_prec)          :: sampleArray2(1:20,1:20)       
+   REAL(real_prec)          :: sampleArray3(1:10,1:10,1:10)       
+   INTEGER                  :: lineNumber
+
+     ! Initialize the ModelDataInstances linked list, by pointing all of the
+     ! pointers to Null
+     CALL mdi % Build( )
+
+     ! Here, the "sampleArray's" are set to initialized values
+     sampleArray1 = 0.0_real_prec
+     sampleArray2 = 0.0_real_prec
+     sampleArray3 = 0.0_real_prec
+
+     ! Grab the line number (if desired)
+     lineNumber = 39
+     ! Here, we add instances for logging the initial condition
+     ! All strings that are passed must be 30 characters or less.
+     !
+     ! This section of code shows how to use the ModelDataInstances data
+     ! structure to add new instances for storing the state of single and
+     ! multidimensional arrays.
+     ! When "AddInstance" is called, more space is allocated to store the array
+     ! and for keeping track of this unique instance. The array is stored within
+     ! the data structure until the user calls the "Trash" routine.
+
+
+
+     ! In practice, you will likely do some work that changes the values stored
+     ! in each of the arrays. Here, the call to "RANDOM_NUMBER" is a proxy for
+     ! doing such work.
+
+     CALL RANDOM_NUMBER( sampleArray1 ) ! Fill SampleArray1 with random data
+     CALL mdi % AddInstance( "ModelDataInstances_Driver.f90", & ! Module name -here we use the main program name 
+                             "Main", &                          ! Subroutine name - here we use "Main" indicating we are not in a subroutine
+                             "Randomize Array1", &              ! Unique name of the status check. Pick something descriptive of what it is.
+                             lineNumber, &                      ! Line number near where this instance was added
+                             SIZE(sampleArray1), &              ! The total number of elements in the array
+                             sampleArray1 )                     ! The array that you want to capture
+
+     CALL RANDOM_NUMBER( sampleArray2 ) ! Fill SampleArray2 with random data
+     CALL mdi % AddInstance( "ModelDataInstances_Driver.f90", & ! Module name -here we use the main program name 
+                             "Main", &                          ! Subroutine name - here we use "Main" indicating we are not in a subroutine
+                             "Randomize Array2", &              ! Unique name of the status check. Pick something descriptive of what it is.
+                             lineNumber, &                      ! Line number near where this instance was added
+                             SIZE(sampleArray2), &              ! The total number of elements in the array
+                             PACK(sampleArray2,.TRUE.) )        ! The array that you want to capture
+
+     CALL RANDOM_NUMBER( sampleArray3 ) ! Fill SampleArray3 with random data
+     CALL mdi % AddInstance( "ModelDataInstances_Driver.f90", & ! Module name -here we use the main program name 
+                             "Main", &                          ! Subroutine name - here we use "Main" indicating we are not in a subroutine
+                             "Randomize Array3", &              ! Unique name of the status check. Pick something descriptive of what it is.
+                             lineNumber, &                      ! Line number near where this instance was added
+                             SIZE(sampleArray3), &              ! The total number of elements in the array
+                             PACK(sampleArray3,.TRUE.) )        ! The array that you want to capture
+
+     ! When writing to file, a file "base name" needs to be passed.
+     ! This call generates, here, mdi.instance.header and mdi.001.instance
+     CALL mdi % Write_ModelDataInstances( 'mdi' )  
+
+     ! It is possible that a particular instance falls
+     ! within a do-loop. The type-bound procedure "Update" keeps track of the
+     ! count. Keep in mind that, unless written to file between updates, stale
+     ! data can be lost.
+     !
+     ! In the current implementation, it is much safer to only track data that
+     ! are updated the same number of times
+     DO i = 1, 3
+       CALL RANDOM_NUMBER( sampleArray1 ) ! Fill SampleArray1 with random data
+       CALL mdi % Update( "Randomize Array1", &              ! Unique name of the status check. Pick something descriptive of what it is.
+                          SIZE(sampleArray1), &              ! The total number of elements in the array
+                          sampleArray1 )                     ! The array that you want to capture
+
+       CALL RANDOM_NUMBER( sampleArray2 ) ! Fill SampleArray2 with random data
+       CALL mdi % Update( "Randomize Array2", &              ! Unique name of the status check. Pick something descriptive of what it is.
+                          SIZE(sampleArray2), &              ! The total number of elements in the array
+                          PACK(sampleArray2,.TRUE.) )        ! The array that you want to capture
+
+       CALL RANDOM_NUMBER( sampleArray3 ) ! Fill SampleArray3 with random data
+       CALL mdi % Update( "Randomize Array3", &              ! Unique name of the status check. Pick something descriptive of what it is.
+                           SIZE(sampleArray3), &             ! The total number of elements in the array
+                           PACK(sampleArray3,.TRUE.) )       ! The array that you want to capture
+
+       ! To avoid losing track of data on each loop, we write the data structure
+       ! to file each time around.
+       CALL mdi % Write_ModelDataInstances( 'mdi' )  
+     ENDDO
+
+
+     ! Here, we clear all of the memory held by the data structure.
+     ! If this driver is run underneath valgrind, there should be no memory
+     ! leaks and no lost or unreachable data.
+     CALL mdi % Trash( )
+
+END PROGRAM ModelDataInstances_Driver

--- a/src/integration_testing/example/ModelDataInstances_Driver.f90
+++ b/src/integration_testing/example/ModelDataInstances_Driver.f90
@@ -78,8 +78,8 @@ PROGRAM ModelDataInstances_Driver
                              PACK(sampleArray3,.TRUE.) )        ! The array that you want to capture
 
      ! When writing to file, a file "base name" needs to be passed.
-     ! This call generates, here, mdi.instance.header and mdi.001.instance
-     CALL mdi % Write_ModelDataInstances( 'mdi' )  
+     ! This call generates, here, test.mdi.hdr and test.0001.mdi
+     CALL mdi % Write_ModelDataInstances( 'test' )  
 
      ! It is possible that a particular instance falls
      ! within a do-loop. The type-bound procedure "Update" keeps track of the
@@ -106,7 +106,7 @@ PROGRAM ModelDataInstances_Driver
 
        ! To avoid losing track of data on each loop, we write the data structure
        ! to file each time around.
-       CALL mdi % Write_ModelDataInstances( 'mdi' )  
+       CALL mdi % Write_ModelDataInstances( 'test' )  
      ENDDO
 
 


### PR DESCRIPTION
A Linked-List structure was created that can be used for instrumenting code with "instance checks". These checks can be used to capture the state of desired arrays during computation and write them to file, so that direct comparisons of data generated by two different model states can be carried out. This instrumentation has not been placed within IPE code yet. However, we will need to consult with each other to determine where we would like to place instrumentation, and merge this into the master branch so that development can continue. Instrumentation will be added within CPP regions, so that production code will not be affected. 

To allow compilation of the "cmdi" tool that performs comparisons between two of these model-data-instance data structures, the environment variable "TESTING" must be set to "yes". This will also be used to enable instrumentation within IPE in a later commit.