### PR TITLE
Development george

### DIFF
--- a/examples/nodensitites_1day_spacewx_80x170/Makefile
+++ b/examples/nodensitites_1day_spacewx_80x170/Makefile
@@ -1,7 +1,10 @@
 
 
-ipe_generic_pgi_serial.exe :
+generic_pgi_serial :
 	make --directory=../../src/ generic_pgi_serial
 
-ipe_generic_intel_serial.exe :
+generic_intel_serial :
 	make --directory=../../src/ generic_intel_serial
+
+clean :
+	make --directory=../../src/ clean

--- a/src/driver/driver_ipe.f90
+++ b/src/driver/driver_ipe.f90
@@ -126,7 +126,10 @@ END IF
 
 ! update plasma
         ret = gptlstart ('plasma')
-        CALL plasma ( utime )
+!ghgm - a dummy timestamp (13 characters) needs to be here
+! because we use timestamps in the fully coupleid WAM-IPE
+! Obviously needs a better solution.....
+        CALL plasma ( utime, 'dummytimestam' )
         ret = gptlstop  ('plasma')
 !sms$compare_var(plasma_3d,"driver_ipe.f90 - plasma_3d-8")
 

--- a/src/eldyn/get_efield90km.f
+++ b/src/eldyn/get_efield90km.f
@@ -171,7 +171,10 @@
       iyr=1999 
 !     iday=97
       utsecs=REAL(utime, real_prec)
+      print *,'GHGM HERE INNIT ', utime, utsecs
+
       CALL sunloc(iyr,NDAY,utsecs) !iyr,iday,secs)        
+
       if (sw_debug) print *,'sunlons(1)',sunlons(1),' iyr',iyr,utsecs
 !     convert from MLT(ylonm)[rad] to mlon[deg]
       mlon130_loop0: DO i=0,nmlon

--- a/src/eldyn/module_sunloc.f
+++ b/src/eldyn/module_sunloc.f
@@ -60,6 +60,7 @@
 !          input: iyr,iday,ihr,imn,sec
 !          output: sbsllat,sbsllon 
 !                  
+      print *,'GHGM YOWZER 1 ',iyr,iday,ihr,imn,isec
       call subsol(iyr,iday,ihr,imn,sec ,sbsllat,sbsllon)
       
       date = float(iyr) + float(iday)/365. + float(ihr)/24./365. +
@@ -73,6 +74,9 @@
       call solgmlon(sbsllat,sbsllon,colat,elon,xmlon) 
 !
       sunlons(1) = xmlon*dtr
+
+      print *,'GHGM YOWZER 2 ',xmlon*dtr
+  
 !      sunlons(1) = 1.247029293721108 ! for cpmapring with TIEGCM code
 !     
       end subroutine sunloc

--- a/src/main/module_close_files.f90
+++ b/src/main/module_close_files.f90
@@ -23,13 +23,7 @@
       CONTAINS
 !---------------------------
         SUBROUTINE close_files ( )
-        USE module_IO,ONLY: PRUNIT,LUN_UT,lun_min1,lun_max1,LUN_PLASMA1 &
-, lun_ipe_grid_neut_params_ut &
-, lun_ipe_grid_neut_wind &
-, lun_ipe_grid_neut_temp &
-, lun_ipe_grid_neut_O_den &
-, lun_ipe_grid_neut_N2_den &
-, lun_ipe_grid_neut_O2_den
+        USE module_IO,ONLY: PRUNIT,LUN_UT,lun_min1,lun_max1,LUN_PLASMA1
 
 USE module_input_parameters,ONLY:sw_output_wind
         IMPLICIT NONE
@@ -42,15 +36,6 @@ DO i=lun_min1,lun_max1
         CLOSE( UNIT=LUN_PLASMA1(i) )
 END DO
 
-!nm20141001
-        IF ( sw_output_wind ) THEN
-          CLOSE(UNIT=lun_ipe_grid_neut_params_ut)
-          CLOSE(UNIT=lun_ipe_grid_neut_wind)
-          CLOSE(UNIT=lun_ipe_grid_neut_temp)
-          CLOSE(UNIT=lun_ipe_grid_neut_O_den)
-          CLOSE(UNIT=lun_ipe_grid_neut_N2_den)
-          CLOSE(UNIT=lun_ipe_grid_neut_O2_den)
-        END IF !( sw_output_wind ) THEN
 
         END SUBROUTINE close_files
 !---------------------------

--- a/src/main/module_close_files.f90
+++ b/src/main/module_close_files.f90
@@ -32,9 +32,6 @@ USE module_input_parameters,ONLY:sw_output_wind
         CLOSE(UNIT=PRUNIT)
         CLOSE(UNIT=LUN_UT)
 
-DO i=lun_min1,lun_max1
-        CLOSE( UNIT=LUN_PLASMA1(i) )
-END DO
 
 
         END SUBROUTINE close_files

--- a/src/main/module_input_parameters.f90
+++ b/src/main/module_input_parameters.f90
@@ -164,13 +164,11 @@
       integer, PUBLIC :: my_comm
 !---
       NAMELIST/IPEDIMS/NLP,NMP,NPTS2D 
-      NAMELIST/NMIPE/start_time &
-     &,stop_time &
+      NAMELIST/NMIPE/ stop_time &
      &,time_step &
      &,F107D   &
      &,F107AV  &
      &,NYEAR  &
-     &,NDAY   &
      &,internalTimeLoopMax &
      &,ip_freq_eldyn &
      &,ip_freq_output &

--- a/src/main/module_input_parameters.f90
+++ b/src/main/module_input_parameters.f90
@@ -164,11 +164,13 @@
       integer, PUBLIC :: my_comm
 !---
       NAMELIST/IPEDIMS/NLP,NMP,NPTS2D 
-      NAMELIST/NMIPE/ stop_time &
+      NAMELIST/NMIPE/ start_time &
+     &, stop_time &
      &,time_step &
      &,F107D   &
      &,F107AV  &
      &,NYEAR  &
+     &,NDAY  &
      &,internalTimeLoopMax &
      &,ip_freq_eldyn &
      &,ip_freq_output &

--- a/src/main/module_io.f90
+++ b/src/main/module_io.f90
@@ -26,7 +26,7 @@
       INTEGER (KIND=int_prec), PARAMETER, PUBLIC :: PRUNIT=8
       INTEGER (KIND=int_prec), PARAMETER, PUBLIC :: LUN_LOG=9
       INTEGER (KIND=int_prec), PUBLIC :: LUN_flip1, LUN_flip2, LUN_flip3, LUN_flip4
-      INTEGER (KIND=int_prec), PUBLIC :: LUN_PLASMA0, LUN_UT, LUN_UT2
+      INTEGER (KIND=int_prec), PUBLIC :: LUN_PLASMA0, LUN_UT
       INTEGER (KIND=int_prec), PARAMETER, PUBLIC :: lun_min1=8000
       INTEGER (KIND=int_prec), PARAMETER, PUBLIC :: lun_max1=lun_min1+ISPEC+3+ISPEV-1+1
       INTEGER (KIND=int_prec), DIMENSION(lun_min1:lun_max1),PUBLIC :: LUN_PLASMA1 !WRITE
@@ -37,15 +37,5 @@
 !nm20120311
       INTEGER (KIND=int_prec), PUBLIC :: luntmp1,luntmp2,luntmp3
 !nm20141001:
-! logical units for files with neutral parameters on the ipe grid......
-      INTEGER (KIND=int_prec), PUBLIC :: lun_ipe_grid_neut_params_ut
-      INTEGER (KIND=int_prec), PUBLIC :: lun_ipe_grid_neut_wind
-      INTEGER (KIND=int_prec), PUBLIC :: lun_ipe_grid_neut_temp
-      INTEGER (KIND=int_prec), PUBLIC :: lun_ipe_grid_neut_O_den
-      INTEGER (KIND=int_prec), PUBLIC :: lun_ipe_grid_neut_N2_den
-      INTEGER (KIND=int_prec), PUBLIC :: lun_ipe_grid_neut_O2_den
-
-      INTEGER (KIND=int_prec), PUBLIC :: LUN_WAM_RESTART0,LUN_WAM_RESTART1,lun_wam_tn
-      INTEGER (KIND=int_prec), PUBLIC :: LUN_WAM_RESTART3,LUN_WAM_RESTART4,LUN_WAM_RESTART5
 
 END MODULE module_IO

--- a/src/main/module_open_output_files.f90
+++ b/src/main/module_open_output_files.f90
@@ -29,17 +29,9 @@
   filename,FORM_dum,STATUS_dum &
 , LUN_pgrid,LUN_LOG &
 , LUN_FLIP1,LUN_FLIP2,LUN_FLIP3,LUN_FLIP4 &
-, LUN_PLASMA0, LUN_PLASMA1,LUN_PLASMA2, LUN_UT, LUN_UT2 &
+, LUN_PLASMA0, LUN_PLASMA1,LUN_PLASMA2, LUN_UT &
 , lun_min1,lun_max1,lun_min2,lun_max2 &
-, record_number_plasma,luntmp1,luntmp2,luntmp3 &
-, lun_ipe_grid_neut_params_ut &
-, lun_ipe_grid_neut_wind &
-, lun_ipe_grid_neut_temp &
-, lun_ipe_grid_neut_O_den &
-, lun_ipe_grid_neut_N2_den &
-, lun_ipe_grid_neut_O2_den &
-, LUN_WAM_RESTART0,LUN_WAM_RESTART1,lun_wam_tn &
-, LUN_WAM_RESTART3,LUN_WAM_RESTART4,LUN_WAM_RESTART5
+, record_number_plasma,luntmp1,luntmp2,luntmp3
 
         USE module_open_file,ONLY: open_file
 
@@ -136,13 +128,6 @@ END IF !( sw_output_plasma_grid ) THEN
 !          filename = 'plasma_startup1'
 !          CALL open_file ( filename, LUN_PLASMA12, FORM_dum, STATUS_dum )
 
-          LUN_UT2=lun_min2-1 !=199
-!nm20120303          filename ='startup_ut_rec.log'
-          filename ='stup_ut_rec'
-          FORM_dum ='formatted  ' 
-          STATUS_dum ='old'
-          CALL open_file ( filename, LUN_UT2, FORM_dum, STATUS_dum )
-
 !--- unit=200~~215
           FORM_dum = 'unformatted' 
 !note: reading Vi will be needed for neutral coupling
@@ -164,108 +149,6 @@ END IF !( sw_output_plasma_grid ) THEN
         END IF  ! ( HPEQ_flip==0.0 ) THEN
 
 
-!nm20141001 WAM output
-        IF ( sw_output_wind ) THEN
-!--- unit=6000 ut for wind
-           lun_ipe_grid_neut_params_ut = 6000
-           filename='ipe_grid_neut_params_ut'
-           print *,'fort.6000? ', filename, lun_ipe_grid_neut_params_ut
-           FORM_dum ='formatted  ' 
-           STATUS_dum ='unknown'
-           CALL open_file ( filename, lun_ipe_grid_neut_params_ut, FORM_dum, STATUS_dum )
-
-!--- unit=6001 wind
-           lun_ipe_grid_neut_wind = 6001
-           filename='ipe_grid_neut_wind'
-           print *,'fort.6001? ', filename, lun_ipe_grid_neut_wind
-           FORM_dum ='unformatted' 
-           STATUS_dum ='unknown'
-           CALL open_file ( filename, lun_ipe_grid_neut_wind, FORM_dum, STATUS_dum ) 
-
-!--- unit=6002 tn
-           lun_ipe_grid_neut_temp = 6002
-           filename='ipe_grid_neut_temp'
-           print *,'fort.6002? ', filename, lun_ipe_grid_neut_temp
-           FORM_dum ='unformatted' 
-           STATUS_dum ='unknown'
-           CALL open_file ( filename, lun_ipe_grid_neut_temp, FORM_dum, STATUS_dum ) 
-
-!--- unit=6003 on: neutral atomic oxygen density
-           lun_ipe_grid_neut_O_den = 6003
-           filename='ipe_grid_neut_O_den'
-           print *,'fort.6003? ', filename, lun_ipe_grid_neut_O_den
-           FORM_dum ='unformatted' 
-           STATUS_dum ='unknown'
-           CALL open_file ( filename, lun_ipe_grid_neut_O_den, FORM_dum, STATUS_dum ) 
-
-!--- unit=6004 on: neutral molecular nitrogen density
-           lun_ipe_grid_neut_N2_den = 6004
-           filename='ipe_grid_neut_N2_den'
-           print *,'fort.6004? ', filename, lun_ipe_grid_neut_N2_den
-           FORM_dum ='unformatted' 
-           STATUS_dum ='unknown'
-           CALL open_file ( filename, lun_ipe_grid_neut_N2_den, FORM_dum, STATUS_dum ) 
-
-!--- unit=6005 on: neutral molecular oxygen density
-           lun_ipe_grid_neut_O2_den = 6005
-           filename='ipe_grid_neut_O2_den'
-           print *,'fort.6004? ', filename, lun_ipe_grid_neut_O2_den
-           FORM_dum ='unformatted' 
-           STATUS_dum ='unknown'
-           CALL open_file ( filename, lun_ipe_grid_neut_O2_den, FORM_dum, STATUS_dum ) 
-
-        END IF !( sw_output_wind
-
-        IF ( sw_use_wam_fields_for_restart ) THEN
-!--- unit=5000 ut for wind
-!          LUN_WAM_RESTART0=5000
-!          filename='ut_out4wind'
-!          print *,'fort.5000? ', filename, LUN_WAM_RESTART0
-!          FORM_dum ='formatted  ' 
-!          STATUS_dum ='old'
-!          CALL open_file ( filename, LUN_WAM_RESTART0, FORM_dum, STATUS_dum )
-
-!--- unit=5001 wind
-           LUN_WAM_RESTART1=15001
-           filename='/scratch3/NCEPDEV/swpc/noscrub/George.Millward/wam-ipe_new_svn/wam_data/ipe_grid_neut_wind'
-           print *,'fort.15001? ', filename, LUN_WAM_RESTART1
-           FORM_dum ='unformatted' 
-           STATUS_dum ='old'
-           CALL open_file ( filename, LUN_WAM_RESTART1, FORM_dum, STATUS_dum ) 
-
-!--- unit=5002 tn
-           lun_wam_tn=15002
-           filename='/scratch3/NCEPDEV/swpc/noscrub/George.Millward/wam-ipe_new_svn/wam_data/ipe_grid_neut_temp'
-           print *,'fort.15002? ', filename, lun_wam_tn
-           FORM_dum ='unformatted' 
-           STATUS_dum ='old'
-           CALL open_file ( filename, lun_wam_tn, FORM_dum, STATUS_dum ) 
-
-!--- unit=5003 on: neutral atomic oxygen density
-           LUN_WAM_RESTART3=15003
-           filename='/scratch3/NCEPDEV/swpc/noscrub/George.Millward/wam-ipe_new_svn/wam_data/ipe_grid_neut_O_den'
-           print *,'fort.15003? ', filename, LUN_WAM_RESTART3
-           FORM_dum ='unformatted' 
-           STATUS_dum ='old'
-           CALL open_file ( filename, LUN_WAM_RESTART3, FORM_dum, STATUS_dum ) 
-
-!--- unit=5004 on: neutral molecular nitrogen density
-           LUN_WAM_RESTART4=15004
-           filename='/scratch3/NCEPDEV/swpc/noscrub/George.Millward/wam-ipe_new_svn/wam_data/ipe_grid_neut_N2_den'
-           print *,'fort.15004? ', filename, LUN_WAM_RESTART4
-           FORM_dum ='unformatted' 
-           STATUS_dum ='old'
-           CALL open_file ( filename, LUN_WAM_RESTART4, FORM_dum, STATUS_dum ) 
-
-!--- unit=5005 on: neutral molecular oxygen density
-           LUN_WAM_RESTART5=15005
-           filename='/scratch3/NCEPDEV/swpc/noscrub/George.Millward/wam-ipe_new_svn/wam_data/ipe_grid_neut_O2_den'
-           print *,'fort.15005? ', filename, LUN_WAM_RESTART5
-           FORM_dum ='unformatted' 
-           STATUS_dum ='old'
-           CALL open_file ( filename, LUN_WAM_RESTART5, FORM_dum, STATUS_dum ) 
-
-        END IF !( sw_use_wam_fields_for_restart
 
         END SUBROUTINE open_output_files
 !---------------------------

--- a/src/main/module_open_output_files.f90
+++ b/src/main/module_open_output_files.f90
@@ -105,21 +105,6 @@ END IF !( sw_output_plasma_grid ) THEN
         CALL open_file ( filename, LUN_UT, FORM_dum, STATUS_dum ) 
 
 
-!--- plasma output: unit=100~~115
-        FORM_dum = 'unformatted' 
-        DO i=lun_min1,lun_max1
-           if(sw_debug) print *,'plasma: unit=',i        
-           LUN_PLASMA1(i)=i
-           IF ( (i-lun_min1) < 10 ) THEN
-              WRITE( string_tmp, FMT="('0',i1)" )(i-lun_min1)
-           ELSE IF ( (i-lun_min1) < 100 ) THEN
-              WRITE( string_tmp, FMT="(i2)" )(i-lun_min1)
-           END IF
-           filename ='plasma'//TRIM(string_tmp)
-           if(sw_debug) print *,(i-lun_min1),'filename',filename
-           CALL open_file ( filename, LUN_PLASMA1(i), FORM_dum, STATUS_dum )
-        END DO
-        record_number_plasma = record_number_plasma_start - 1
 
         IF ( HPEQ_flip==0.0 ) THEN
 !--- unit=1181 : input history file

--- a/src/neutral/module_neutral.f90
+++ b/src/neutral/module_neutral.f90
@@ -159,11 +159,6 @@ END IF
      &                 , tinf_k(IN:IS,lp,mp) &
      &                 , Vn_ms1(1:3,1:NPTS))
 
-if (mp == 1 .and. lp == 1) then
-do i = in , is
-print *,'THISS ',i,tn_k_msis(i,lp,mp),tn_k(i,mp,lp)
-enddo
-endif
 !
 ! copy across the msis parameters:
 !
@@ -201,11 +196,9 @@ endif
       midpoint = IN + (IS-IN)/2
 
 !dbg20160715: temporarily change the code to use MSIS/HWM for the 1st time step, because wamfield is not ready for the 1st time step for a reason...
-      print*,' YAMPA0 BEFORE utime 432000 if block ',utime
       if ( utime==432000 ) then
          IF( sw_debug ) print*,mype,mp,lp,'MSIS utime=',utime         
       else if ( utime>432000 ) then
-      print*,' YAMPA0 BEFORE then HERE ',utime
 
          if ( sw_neutral==3 ) then
             if(lp==1)print*,mype,mp,'MSIS',sw_neutral,utime
@@ -239,10 +232,8 @@ endif
 
 
          jth=1   
-         IF (lp==1) print*,mp,' YAMPA0 calculating wam Tn',jth,swNeuPar(jth)
          if ( swNeuPar(jth) ) then
 !            IF (sw_debug.and.lp==1) print*,mp,'calculating wam Tn',jth 
-            IF (lp==1) print*,mp,' YAMPA calculating wam Tn',jth 
             !below 800km: NH
             tn_k(IN:ihTopN,lp,mp)   = WamField(IN:ihTopN,lp,mp, jth) !Tn NH
             !below 800km: SH
@@ -604,17 +595,6 @@ end if !sw_neutral
 !SMS$PARALLEL END
 
 !      IF ( ALLOCATED(AP_dum) )  DEALLOCATE ( AP_dum )
-	print *, ' GEORGE JMIN_IN TOTAL ', JMIN_IN
-	print *, ' GEORGE JMIN_IN(10) ', JMIN_IN(10)
-	print *, ' GEORGE JMAX_IS TOTAL ', JMAX_IS
-	print *, ' GEORGE JMAX_IS(10) ', JMAX_IS(10)
-      print *,'*** GEORGE IN NEUTRAL ',tn_k(JMIN_IN(10)+2,10,10)
-      print *,'*** GEORGE IN NEUTRAL ',tn_k_msis(JMIN_IN(10)+2,10,10)
-	 print *,'***** THIS BNOW ',tn_k(JMIN_IN(10)+2,10,10)
-	 print *,'***** THIS BNOW2 ',Un_ms1(JMIN_IN(10)+2,10,10,1),Un_ms1(JMIN_IN(10)+2,10,10,2),Un_ms1(JMIN_IN(10)+2,10,10,3)
-	 print *,'***** THIS BNOW3 ',on_m3(JMIN_IN(10)+2,10,10)
-     print *,'***** THIS BNOW4 ',n2n_m3(JMIN_IN(10)+2,10,10)
-     print *,'***** THIS BNOW5 ',o2n_m3(JMIN_IN(10)+2,10,10)
       end subroutine neutral
 
       END MODULE module_NEUTRAL_MKS

--- a/src/plasma/io_plasma_bin.f90
+++ b/src/plasma/io_plasma_bin.f90
@@ -75,7 +75,7 @@ IF ( switch==1 ) THEN !1:Output the 16 plasma* files
 
   OPEN( UNIT = 5999, &
         FILE = 'ipe_grid_plasma_params.'//timestamp_for_IPE, &
-        FORM = 'UNFORMATTED',
+        FORM = 'UNFORMATTED', &
         STATUS = 'REPLACE', &
         CONVERT = 'BIG_ENDIAN', &
         IOSTAT = iErr )
@@ -128,7 +128,7 @@ IF ( switch==1 ) THEN !1:Output the 16 plasma* files
 
     OPEN( UNIT = 5998, &
         FILE = 'ipe_grid_neutral_params.'//timestamp_for_IPE, &
-        FORM = 'UNFORMATTED',
+        FORM = 'UNFORMATTED', &
         STATUS = 'REPLACE', &
         CONVERT = 'BIG_ENDIAN', &
         IOSTAT = iErr )
@@ -167,13 +167,13 @@ ELSE IF ( switch==2 ) THEN !2:RESTART:
 #endif  
 
   OPEN( UNIT = 5997, &
-        FILE = trim(restart_directory)//'ipe_grid_plasma_params, &
-        FORM = 'UNFORMATTED',
+        FILE = trim(restart_directory)//'ipe_grid_plasma_params', &
+        FORM = 'UNFORMATTED', &
         STATUS = 'OLD', &
         CONVERT = 'BIG_ENDIAN', &
         IOSTAT = iErr )
   IF( iErr /= 0 )THEN
-    PRINT*, 'sub-io_plasma_bin : Error Opening file '//trim(restart_directory)//'ipe_grid_plasma_params
+    PRINT*, 'sub-io_plasma_bin : Error Opening file '//trim(restart_directory)//'ipe_grid_plasma_params'
     STOP
   ENDIF
     
@@ -206,13 +206,13 @@ ELSE IF ( switch==2 ) THEN !2:RESTART:
 #endif  
 
   OPEN( UNIT = 5996, &
-        FILE = trim(restart_directory)//'ipe_grid_neutral_params, &
-        FORM = 'UNFORMATTED',
+        FILE = trim(restart_directory)//'ipe_grid_neutral_params', &
+        FORM = 'UNFORMATTED', &
         STATUS = 'OLD', &
         CONVERT = 'BIG_ENDIAN', &
         IOSTAT = iErr )
   IF( iErr /= 0 )THEN
-    PRINT*, 'sub-io_plasma_bin : Error Opening file '//trim(restart_directory)//'ipe_grid_neutral_params
+    PRINT*, 'sub-io_plasma_bin : Error Opening file '//trim(restart_directory)//'ipe_grid_neutral_params'
     STOP
   ENDIF
 

--- a/src/plasma/io_plasma_bin.f90
+++ b/src/plasma/io_plasma_bin.f90
@@ -14,26 +14,26 @@
 ! PHONE  : 303-497-4857
 ! ADDRESS: 325 Broadway, Boulder, CO 80305
 !--------------------------------------------        
-SUBROUTINE io_plasma_bin ( switch, utime )
+SUBROUTINE io_plasma_bin ( switch, utime, timestamp_for_IPE )
 USE module_precision
-USE module_IO,ONLY: LUN_PLASMA1,LUN_PLASMA2,lun_min1,lun_min2,lun_ut,lun_ut2,record_number_plasma,lun_max1 &
-, lun_ipe_grid_neut_params_ut &
-, lun_ipe_grid_neut_wind &
-, lun_ipe_grid_neut_temp &
-, lun_ipe_grid_neut_O_den &
-, lun_ipe_grid_neut_N2_den &
-, lun_ipe_grid_neut_O2_den &
-,LUN_WAM_RESTART0,LUN_WAM_RESTART1,lun_wam_tn,LUN_WAM_RESTART3,LUN_WAM_RESTART4,LUN_WAM_RESTART5
+USE module_IO,ONLY: LUN_PLASMA1,LUN_PLASMA2,lun_min1,lun_min2,lun_ut,record_number_plasma,lun_max1
+
 USE module_FIELD_LINE_GRID_MKS,ONLY: JMIN_IN,JMAX_IS,plasma_3d,JMIN_ING,JMAX_ISG,VEXBup &
 &, Un_ms1,tn_k,on_m3,n2n_m3,o2n_m3
 USE module_IPE_dimension,ONLY: NMP,NLP,NPTS2D,ISPEC,ISPEV,IPDIM,ISPET,ISTOT
 USE module_input_parameters,ONLY:sw_debug,record_number_plasma_start,mype &
 &,sw_record_number,stop_time,start_time,duration,mpstop, sw_output_wind, sw_use_wam_fields_for_restart
 USE module_physical_constants,ONLY:zero
+! ghgm - now need the open_file module....
+USE module_open_file,ONLY: open_file
+
+!USE module_myIPE_Init, only: model_start_time, model_stop_time
+
 IMPLICIT NONE
 
 INTEGER (KIND=int_prec ),INTENT(IN) :: switch !2:read; 1:write
 INTEGER (KIND=int_prec ),INTENT(IN) :: utime !universal time [sec]
+character(len=13), INTENT(IN) :: timestamp_for_IPE
 INTEGER (KIND=int_prec ),PARAMETER  :: n_max=10000
 INTEGER (KIND=int_prec )            :: stat_alloc
 INTEGER (KIND=int_prec )            :: jth,mp,lp,npts
@@ -42,6 +42,9 @@ INTEGER (KIND=int_prec )            :: n_read,n_read_min, utime_dum,record_numbe
 INTEGER (KIND=int_prec )            :: n_count
 INTEGER (KIND=int_prec )            :: ipts !dbg20120501
 REAL    (KIND=real_prec)            :: dumm(NPTS2D,NMP)
+CHARACTER(len=80) :: restart_directory
+CALL getenv("RESDIR", restart_directory)
+print *, 'GHGM IO_PLASMA restart_directory ',TRIM(restart_directory)
 
 IF ( switch<1.or.switch>2 ) THEN
   print *,'sub-io_plasma:!STOP! INVALID switch',switch
@@ -57,8 +60,13 @@ dumm=zero
 
 IF ( switch==1 ) THEN !1:Output the 16 plasma* files
 
+
   record_number_plasma = record_number_plasma+1
 !SMS$SERIAL(<plasma_3d,IN>:default=ignore) BEGIN
+
+! ghgm - open the new plasma file unit......
+call open_file('ipe_grid_plasma_params.'//timestamp_for_IPE,5999,'unformatted','unknown')
+
   j_loop1: DO jth=1,ISTOT !=(ISPEC+3+ISPEV)
     mp_loop1:do mp=1,mpstop
       lp_loop1:do lp=1,nlp
@@ -73,7 +81,14 @@ IF ( switch==1 ) THEN !1:Output the 16 plasma* files
     if(sw_debug) print *,'jth=',jth,' LUN=',LUN
     WRITE (UNIT=lun) (dumm(:,mp),mp=1,mpstop)
     if(sw_debug) print *,'!dbg! output dummy finished'
+
+! ghgm - also write the 16 plasma files to a single unit.....
+write (unit=5999) (dumm(:,mp),mp=1,mpstop)
+
   END DO j_loop1!jth
+! ghgm - and then close the file
+close (unit=5999)
+
 !SMS$SERIAL END
   LUN = LUN_PLASMA1(lun_max1)
 !SMS$SERIAL(<VEXBup,IN>:default=ignore) BEGIN
@@ -83,23 +98,17 @@ IF ( switch==1 ) THEN !1:Output the 16 plasma* files
 
 !nm20141001: moved from neutral
       IF ( sw_output_wind ) THEN
-!nm20160711 debug wam field: 
-!SMS$SERIAL(<tn_k,IN>:default=ignore) BEGIN
-    write (UNIT=lun_ipe_grid_neut_temp) tn_k
-    write (UNIT=lun_ipe_grid_neut_params_ut,FMT=*) utime
+
+!SMS$SERIAL(<tn_k,Un_ms1,on_m3,n2n_m3,o2n_m3,IN>:default=ignore) BEGIN
+call open_file('ipe_grid_neutral_params.'//timestamp_for_IPE,5998,'unformatted','unknown')
+    write (unit=5998) tn_k
+    write (unit=5998) un_ms1
+    write (unit=5998) on_m3 
+    write (unit=5998) n2n_m3
+    write (unit=5998) o2n_m3
+close (unit=5998)
 !SMS$SERIAL END
-!SMS$SERIAL(<Un_ms1,IN>:default=ignore) BEGIN
-           write (UNIT=lun_ipe_grid_neut_wind) Un_ms1
-!SMS$SERIAL END
-!SMS$SERIAL(<on_m3,IN>:default=ignore) BEGIN
-           write (UNIT=lun_ipe_grid_neut_O_den) on_m3
-!SMS$SERIAL END
-!SMS$SERIAL(<n2n_m3,IN>:default=ignore) BEGIN
-           write (UNIT=lun_ipe_grid_neut_N2_den) n2n_m3
-!SMS$SERIAL END
-!SMS$SERIAL(<o2n_m3,IN>:default=ignore) BEGIN
-           write (UNIT=lun_ipe_grid_neut_O2_den) o2n_m3
-!SMS$SERIAL END
+
       END IF !( sw_output_wind ) THEN
 
 
@@ -107,124 +116,44 @@ IF ( switch==1 ) THEN !1:Output the 16 plasma* files
     print *,'LUN=',lun_ut,'!dbg! output UT  finished: utime=',utime,record_number_plasma
   endif
 
-ELSE IF ( switch==2 ) THEN !2:RESTART: Read from the 16 plasma* files
+ELSE IF ( switch==2 ) THEN !2:RESTART: 
 
-  print *,'sub-io_pl: start_uts=',utime
-!SMS$PARALLEL(dh, lp, mp) BEGIN
-  ! array initialization
-  DO mp=1,NMP
-    DO lp=1,NLP
-      DO ipts=JMIN_IN(lp),JMAX_IS(lp)
-        DO jth=1,ISTOT
-          plasma_3d(ipts,lp,mp,jth) = zero
-        END DO!j
-      END DO!ipts
-    END DO!lp
-  END DO!mp
-  !nm20120509: automatically keep running global run
-  !0:you need to specify the record_number_plasma_start by your self...
-  IF ( sw_record_number==0 ) THEN
 !SMS$SERIAL BEGIN
-    rd_loop0: DO n_read=1,n_max !=10000
-      READ (UNIT=lun_ut2,FMT=*) record_number_plasma_dum, utime_dum
-      print *,' record_# ', record_number_plasma_dum,' uts=', utime_dum
-      IF (n_read==1) THEN
-        n_read_min=record_number_plasma_dum
-        print *,'n_read=',n_read,'n_read_min=', n_read_min
-      END IF
-      IF (record_number_plasma_dum==record_number_plasma_start) THEN
-        IF (utime_dum==utime) THEN
-          print *,'n_read=',n_read,' confirmed that ipe output exist at rec#=',record_number_plasma_dum,' at UT=', utime_dum
-          CLOSE(UNIT=lun_ut2)
-          EXIT  rd_loop0
-        ELSE !IF (utime_dum/=utime) THEN
-          print *,'n_read',n_read,'!STOP! INVALID start_time!',utime, record_number_plasma_dum, utime_dum
-          STOP
-        END IF
-      ELSE IF (n_read==n_max.OR.record_number_plasma_dum>record_number_plasma_start) THEN
-        print *,'n_read',n_read,'!STOP! INVALID record number!',record_number_plasma_dum, utime_dum
-        STOP
-      END IF
-    END DO rd_loop0!: DO n_read=1,n_max          
-!SMS$SERIAL END
-  ELSE IF ( sw_record_number==1 ) THEN
-  !1: automatically keep running global run: the code sets up the record_number from the very last record...
-!SMS$SERIAL(<record_number_plasma_start,start_time,n_read_min,OUT>:default=ignore) BEGIN
-    n_count=0
-    rd_loop1: DO n_read=1,n_max !=10000
-      READ (UNIT=lun_ut2,FMT=*,END=19) record_number_plasma_dum, utime_dum
-      n_count=n_count+1
-      IF (n_read==1) THEN
-        n_read_min=record_number_plasma_dum
-        print *,'n_read=',n_read,'n_read_min=', n_read_min
-      END IF
-    END DO rd_loop1!: DO n_read=1,n_max !=10000
-19  CONTINUE
-    record_number_plasma_start = record_number_plasma_dum
-    start_time = utime_dum
-    print *,'new record_number_plasma_start=',record_number_plasma_start
-    print *,'new start_time=',start_time
-!SMS$SERIAL END
-    stop_time = start_time + duration
-    print *,'new stop_time=',stop_time,' duration=', duration
-  END IF !( sw_record_number==0 ) THEN        
-!SMS$SERIAL BEGIN
-  j_loop2: DO jth=1,(ISPEC+3)  !t  +ISPEV)
-    LUN = LUN_PLASMA2(jth-1+lun_min2)
-    if(sw_debug) print *,'jth=',jth,' LUN2=',LUN
-    rd_loop: DO n_read=n_read_min, record_number_plasma_start
-      if(jth==ISPEC+3) print *,'n_read=',n_read
-      READ (UNIT=lun ) dumm
-      if (jth==ISPEC+3) print *,'!dbg! read dummy finished jth',jth
-    END DO rd_loop !: DO n_read=1,n_read_max
-    mp_loop2:do mp=1,NMP
-      lp_loop2:do lp=1,NLP
+! ghgm - read in saved plasma_3d data.....
+!restart_directory='/scratch3/NCEPDEV/swpc/noscrub/George.Millward/restart_directory/'
+print *,' ghgm reading in plasma_3d'
+call open_file(trim(restart_directory) // 'ipe_grid_plasma_params',5997,'unformatted','old')
+j_loop3: DO jth=1,(ISPEC+3)
+    read (unit=5997) dumm
+    mp_loop3:do mp=1,NMP
+      lp_loop3:do lp=1,NLP
         IN   = JMIN_IN(lp)
         IS   = JMAX_IS(lp)
         npts = IS-IN+1 
         plasma_3d(IN:IS,lp,mp,jth) = dumm(JMIN_ING(lp):JMAX_ISG(lp),mp) 
-      end do lp_loop2!lp
-    end do mp_loop2!mp
-    print *,'closing lun',LUN
-    CLOSE(LUN)
-  END DO j_loop2!jth
+      end do lp_loop3
+    end do mp_loop3
+END DO j_loop3
+close(5997)
+print *,' ghgm done reading in plasma_3d'
 !SMS$SERIAL END
 
-! Read in the WAM startup fields.... 
-IF ( sw_use_wam_fields_for_restart ) THEN
 !SMS$SERIAL BEGIN
-print *,'****** GEORGE ******* READING WAM TN 1'
-  read (UNIT=lun_wam_tn) tn_k
-print *,'****** GEORGE ******* READING WAM TN 2'
-  read (UNIT=lun_wam_tn) tn_k
-print *,'***** THIS INNIT ',tn_k(JMIN_IN(10)+2,10,10)
-print *,'***** THIS TOOOOO INNIT '
-  close(lun_wam_tn)
-!  read (UNIT=LUN_WAM_RESTART0,FMT=*) utime
-!  close(LUN_WAM_RESTART0)
-print *,'****** GEORGE ******* READING WAM WIND'
-  read (UNIT=LUN_WAM_RESTART1) Un_ms1
-print *,'***** THIS INNIT2 ',Un_ms1(JMIN_IN(10)+2,10,10,1),Un_ms1(JMIN_IN(10)+2,10,10,2),Un_ms1(JMIN_IN(10)+2,10,10,3)
-  close(LUN_WAM_RESTART1)
-print *,'****** GEORGE ******* READING WAM ON'
-  read (UNIT=LUN_WAM_RESTART3) on_m3
-print *,'***** THIS INNIT3 ',on_m3(JMIN_IN(10)+2,10,10)
-  close(LUN_WAM_RESTART3)
-print *,'****** GEORGE ******* READING WAM N2N'
-  read (UNIT=LUN_WAM_RESTART4) n2n_m3
-print *,'***** THIS INNIT4 ',n2n_m3(JMIN_IN(10)+2,10,10)
-  close(LUN_WAM_RESTART4)
-print *,'****** GEORGE ******* READING WAM O2N'
-  read (UNIT=LUN_WAM_RESTART5) o2n_m3
-print *,'***** THIS INNIT5 ',o2n_m3(JMIN_IN(10)+2,10,10)
-  close(LUN_WAM_RESTART5)
-print *,'****** GEORGE ******* DONE READING WAM FIELDS'
+! ghgm - read in saved WAM neutral parameters.....
+!restart_directory='/scratch3/NCEPDEV/swpc/noscrub/George.Millward/restart_directory/'
+print *,' ghgm reading in wam neutrals'
+call open_file(trim(restart_directory) // 'ipe_grid_neutral_params',5996,'unformatted','old')
+    read (unit=5996) tn_k
+    read (unit=5996) un_ms1
+    read (unit=5996) on_m3 
+    read (unit=5996) n2n_m3
+    read (unit=5996) o2n_m3
+close(5996)
+print *,' ghgm done reading in wam neutrals'
 !SMS$SERIAL END
-END IF
+
 
 END IF !( switch==1 ) THEN
-
-!SMS$PARALLEL END
 
 
 print *,'END sub-io_pl: sw=',switch,' uts=' ,utime 

--- a/src/plasma/io_plasma_bin.f90
+++ b/src/plasma/io_plasma_bin.f90
@@ -72,12 +72,10 @@ IF ( switch==1 ) THEN !1:Output the 16 plasma* files
   ! If debugging is enabled, the activity throughout the code is logged.
   WRITE( UNIT=LUN_LOG, FMT=*) 'opening file: ipe_grid_plasma_params.'//timestamp_for_IPE
 #endif
-
   OPEN( UNIT = 5999, &
         FILE = 'ipe_grid_plasma_params.'//timestamp_for_IPE, &
         FORM = 'UNFORMATTED', &
         STATUS = 'REPLACE', &
-        CONVERT = 'BIG_ENDIAN', &
         IOSTAT = iErr )
   IF( iErr /= 0 )THEN
     PRINT*, 'sub-io_plasma_bin : Error Opening file ipe_grid_plasma_params.'//timestamp_for_IPE//' for writing.'
@@ -111,9 +109,9 @@ IF ( switch==1 ) THEN !1:Output the 16 plasma* files
   CLOSE(unit=5999)
 
 !SMS$SERIAL END
-  LUN = LUN_PLASMA1(lun_max1)
+!  LUN = LUN_PLASMA1(lun_max1)
 !SMS$SERIAL(<VEXBup,IN>:default=ignore) BEGIN
-  WRITE (UNIT=LUN) (VEXBup(:,mp),mp=1,mpstop)
+!  WRITE (UNIT=LUN) (VEXBup(:,mp),mp=1,mpstop)
   WRITE (UNIT=lun_ut,FMT=*) record_number_plasma, utime
 !SMS$SERIAL END
 
@@ -130,7 +128,6 @@ IF ( switch==1 ) THEN !1:Output the 16 plasma* files
         FILE = 'ipe_grid_neutral_params.'//timestamp_for_IPE, &
         FORM = 'UNFORMATTED', &
         STATUS = 'REPLACE', &
-        CONVERT = 'BIG_ENDIAN', &
         IOSTAT = iErr )
     IF( iErr /= 0 )THEN
       PRINT*, 'sub-io_plasma_bin : Error Opening file ipe_grid_neutral_params.'//timestamp_for_IPE
@@ -170,7 +167,6 @@ ELSE IF ( switch==2 ) THEN !2:RESTART:
         FILE = trim(restart_directory)//'ipe_grid_plasma_params', &
         FORM = 'UNFORMATTED', &
         STATUS = 'OLD', &
-        CONVERT = 'BIG_ENDIAN', &
         IOSTAT = iErr )
   IF( iErr /= 0 )THEN
     PRINT*, 'sub-io_plasma_bin : Error Opening file '//trim(restart_directory)//'ipe_grid_plasma_params'
@@ -209,7 +205,6 @@ ELSE IF ( switch==2 ) THEN !2:RESTART:
         FILE = trim(restart_directory)//'ipe_grid_neutral_params', &
         FORM = 'UNFORMATTED', &
         STATUS = 'OLD', &
-        CONVERT = 'BIG_ENDIAN', &
         IOSTAT = iErr )
   IF( iErr /= 0 )THEN
     PRINT*, 'sub-io_plasma_bin : Error Opening file '//trim(restart_directory)//'ipe_grid_neutral_params'

--- a/src/plasma/io_plasma_bin.f90
+++ b/src/plasma/io_plasma_bin.f90
@@ -77,11 +77,6 @@ call open_file('ipe_grid_plasma_params.'//timestamp_for_IPE,5999,'unformatted','
       end do lp_loop1!lp
     end do mp_loop1!mp
 
-    LUN = LUN_PLASMA1(jth-1+lun_min1)
-    if(sw_debug) print *,'jth=',jth,' LUN=',LUN
-    WRITE (UNIT=lun) (dumm(:,mp),mp=1,mpstop)
-    if(sw_debug) print *,'!dbg! output dummy finished'
-
 ! ghgm - also write the 16 plasma files to a single unit.....
 write (unit=5999) (dumm(:,mp),mp=1,mpstop)
 
@@ -120,7 +115,6 @@ ELSE IF ( switch==2 ) THEN !2:RESTART:
 
 !SMS$SERIAL BEGIN
 ! ghgm - read in saved plasma_3d data.....
-!restart_directory='/scratch3/NCEPDEV/swpc/noscrub/George.Millward/restart_directory/'
 print *,' ghgm reading in plasma_3d'
 call open_file(trim(restart_directory) // 'ipe_grid_plasma_params',5997,'unformatted','old')
 j_loop3: DO jth=1,(ISPEC+3)
@@ -140,7 +134,6 @@ print *,' ghgm done reading in plasma_3d'
 
 !SMS$SERIAL BEGIN
 ! ghgm - read in saved WAM neutral parameters.....
-!restart_directory='/scratch3/NCEPDEV/swpc/noscrub/George.Millward/restart_directory/'
 print *,' ghgm reading in wam neutrals'
 call open_file(trim(restart_directory) // 'ipe_grid_neutral_params',5996,'unformatted','old')
     read (unit=5996) tn_k

--- a/src/plasma/module_sub_plasma.f90
+++ b/src/plasma/module_sub_plasma.f90
@@ -28,7 +28,7 @@
 
       CONTAINS
 !---------------------------
-      SUBROUTINE plasma ( utime )
+      SUBROUTINE plasma ( utime, timestamp_for_IPE )
       USE module_input_parameters,ONLY:mpstop,ip_freq_output,start_time,stop_time,&
 &     sw_neutral_heating_flip,sw_perp_transport,lpmin_perp_trans,lpmax_perp_trans,sw_para_transport,sw_debug,        &
 &     sw_dbg_perp_trans,sw_exb_up,parallelBuild,mype, &
@@ -46,6 +46,7 @@
       INTEGER (KIND=int_prec) :: i,j,midpoint, i1d,k,ret  !dbg20120501
       INTEGER (KIND=int_prec) :: jth  !dbg20120501
       integer :: status
+      character(len=13), INTENT(IN) :: timestamp_for_IPE
 !d      INTEGER :: lun_dbg=999
 !t      REAL(KIND=real_prec) :: phi_t0   !magnetic longitude,phi at T0
 !t      REAL(KIND=real_prec) :: theta_t0 !magnetic latitude,theta at T0
@@ -62,6 +63,7 @@ end if
 
 ! save ut so that other subroutines can refer to it
       utime_save=utime
+      print *, 'GHGM IN PLASMA, UTIME : ', utime
 
       ret = gptlstart ('apex_lon_loop') !24772.857
 !SMS$PARALLEL(dh, lp, mp) BEGIN
@@ -238,11 +240,13 @@ endif
 ! output plasma parameters to a file
       ret = gptlstart ('io_plasma_bin')
 write(6,*)'BEFORE MOD check output plasma',utime,start_time,ip_freq_output
-      IF ( MOD( (utime-start_time),ip_freq_output)==0 ) THEN 
+! ghgm output every time for now......
+!      IF ( MOD( (utime-start_time),ip_freq_output)==0 ) THEN 
+!
 write(6,*)'before call to output plasma',utime,start_time,ip_freq_output
 !dbg20110923segmentation fault??? memory allocation run time error???
 !sms$compare_var(plasma_3d,"module_sub_plasma.f90 - plasma_3d-5")
-        CALL io_plasma_bin ( 1, utime )
+        CALL io_plasma_bin ( 1, utime, timestamp_for_IPE)            
 !sms$compare_var(plasma_3d,"module_sub_plasma.f90 - plasma_3d-6")
 
 !dbg20110927: o+ only
@@ -252,7 +256,7 @@ write(6,*)'before call to output plasma',utime,start_time,ip_freq_output
 !d if (utime==stop_time)   close(unit=lun_dbg)
 !d END IF !( sw_perp_transport>=1 ) THEN
 
-      END IF      !IF ( MOD( (utime-start_time),ip_freq_output)==0 ) THEN 
+!      END IF      !IF ( MOD( (utime-start_time),ip_freq_output)==0 ) THEN 
       ret = gptlstop ('io_plasma_bin')
 !sms$compare_var(plasma_3d,"module_sub_plasma.f90 - plasma_3d-7")
 


### PR DESCRIPTION
Here we are bringing in George's modifications to the development branch.

**The development branch currently includes**

* Naomi's adjustments from the June 13 master commit

* Joe's addition of the MDI class, the CMDI program, the instrumentation in driver_ipe.f90, and adjustments to the makefile. The makefile adjustments permit building for a generic system in serial with intel, pgi, and gnu compilers. Additionally, building the code with instrumentation is controlled with the TESTING environment variable. When TESTING=yes, the MDI instrumentation is enabled. Otherwise it is off. This functionality has been tested before this current merge with George's work.

**Things we will need to resolve** 

* George needed to remove the NDAY and start_time parameters from the NMIPE namelist in order to get the code to work with WAM-IPE. We need a clean way to keep these parameters in the namelist so the standalone version can work, while also allowing these variables to be overwritten when run with WAM-IPE.

* George's version now outputs plasma and neutral files in his new file format - one single file replacing the dozen or so individual files. We should decide if we want to continue supporting the old file format. If not, we should remove the old I/O.

* We need to ensure the build system still functions on theia and yellowstone before completing the merge.

* We need to make sure Naomi's adjustments are kept.

* When IPE  runs in standalone, the new I/O appends a "dummytimestamp" to the end of the file. We should have a cleaner convention for the standalone version that outputs a meaningful timestamp at the end of the file.