### PR TITLE
Made MPI_COMM_IPE a global scope parameter so that WAM-IPE will funct…

### DIFF
--- a/src/driver/driver_ipe.f90
+++ b/src/driver/driver_ipe.f90
@@ -57,6 +57,7 @@ PROGRAM  test_plasma
 !SMS$INSERT parallelBuild=.true.
 ! set up input parameters
      ret = gptlstart ('read_input')
+!SMS$INSERT         MPI_COMM_IPE = MPI_COMM_WORLD
      CALL read_input_parameters ( )
      ret = gptlstop  ('read_input')
 
@@ -319,7 +320,7 @@ PROGRAM  test_plasma
 !ghgm - a dummy timestamp (13 characters) needs to be here
 ! because we use timestamps in the fully coupleid WAM-IPE
 ! Obviously needs a better solution.....
-        CALL plasma ( utime, 'dummytimestam' )
+        CALL plasma ( utime_driver, 'dummytimestam' )
         ret = gptlstop  ('plasma')
 
 !sms$compare_var(plasma_3d,"driver_ipe.f90 - plasma_3d-8")
@@ -335,9 +336,9 @@ PROGRAM  test_plasma
 #endif
 !SMS$IGNORE END
 
-       IF( MOD(REAL(utime,real_prec),dumpFrequency)==0)THEN
-          WRITE( iterChar, '(I8.8)' ) iterate
-          CALL io_plasma_bin ( 1, utime, 'iter_'//iterChar )
+       IF( MOD(REAL(utime_driver,real_prec),dumpFrequency)==0)THEN
+          WRITE( iterChar, '(I8.8)' )utime_driver
+          CALL io_plasma_bin ( 1, utime_driver, 'iter_'//iterChar )
        ENDIF
        ret = gptlstart ('output')
        CALL output ( utime_driver )

--- a/src/main/module_input_parameters.f90
+++ b/src/main/module_input_parameters.f90
@@ -159,7 +159,8 @@
 !0: div * V//=0
 !1: div * V// included in the Te/i solver
 !dbg20120313 
-      REAL(KIND=real_prec), PUBLIC :: fac_BM
+      REAL(KIND=real_prec), PUBLIC    :: fac_BM
+      INTEGER (KIND=int_prec), PUBLIC :: MPI_COMM_IPE        
 !
 !---
       NAMELIST/IPEDIMS/NLP,NMP,NPTS2D 
@@ -265,7 +266,6 @@
         CHARACTER (LEN=*), PARAMETER :: filename='logfile_input_params.log'
         INTEGER (KIND=int_prec) :: istat        
         !MPI communicator to be passed to SMS
-        INTEGER (KIND=int_prec) :: MPI_COMM_IPE        
 
 !SMS$IGNORE BEGIN
         OPEN(LUN_nmlt,FILE=INPTNMLT,ERR=222,IOSTAT=IOST_OP,STATUS='OLD')
@@ -280,7 +280,7 @@
 !
 !set up MPI communicator for SMS
 !(1) when NEMS is not used, pass MPI_COMM_WORLD into SET_COMMUNICATOR()
-!SMS$INSERT         MPI_COMM_IPE = MPI_COMM_WORLD
+!>>>>>>>>SMS$INSERT         MPI_COMM_IPE = MPI_COMM_WORLD
 !(2) when NEMS is used, my_comm=mpiCommunicator has been assigned already in sub-myIPE_Init
 !        print *, 'sub-read_input_para:my_comm=', my_comm
 !SMS$SET_COMMUNICATOR( MPI_COMM_IPE )


### PR DESCRIPTION
…ion properly. Moved MPI_COMM_IPE=MPI_COMM_WORLD from module_input_parameters to driver to prevent overwriting the MPI_COMM_IPE communicator in WAM-IPE